### PR TITLE
Preparation for release 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.axibase</groupId>
     <artifactId>mvel2</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.5.7</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <name>mvel</name>
     <url>http://mvel.codehaus.org/</url>

--- a/src/main/java/org/mvel2/MVEL.java
+++ b/src/main/java/org/mvel2/MVEL.java
@@ -48,8 +48,8 @@ import static org.mvel2.util.ParseTools.optimizeTree;
  */
 public class MVEL {
   public static final String NAME = "MVEL (MVFLEX Expression Language)";
-  public static final String VERSION = "2.4";
-  public static final String VERSION_SUB = "5";
+  public static final String VERSION = "3.0";
+  public static final String VERSION_SUB = "0";
   public static final String CODENAME = "liberty";
   static boolean DEBUG_FILE = getBoolean("mvel2.debug.fileoutput");
   static String ADVANCED_DEBUGGING_FILE = System.getProperty("mvel2.debugging.file") == null ? "mvel_debug.txt" : System.getProperty("mvel2.debugging.file");

--- a/src/main/java/org/mvel2/integration/VariableResolver.java
+++ b/src/main/java/org/mvel2/integration/VariableResolver.java
@@ -21,7 +21,7 @@ package org.mvel2.integration;
 import java.io.Serializable;
 
 /**
- * A variable resolver is responsible for physically accessing a variable, for either read or write.  VariableResolver's
+ * A variable resolver is responsible for physically accessing a variable, for either read or write.  VariableResolvers
  * are obtained via a {@link org.mvel2.integration.VariableResolverFactory}.
  */
 public interface VariableResolver extends Serializable {
@@ -33,7 +33,7 @@ public interface VariableResolver extends Serializable {
   public String getName();
 
   /**
-   * This should return the type of the variable.  However, this is not completely necessary, and is particularily
+   * This should return the type of the variable.  However, this is not completely necessary, and is particularly
    * only of benefit to systems that require use of MVEL's strict typing facilities.  In most cases, this implementation
    * can simply return: Object.class
    *
@@ -48,7 +48,7 @@ public interface VariableResolver extends Serializable {
 
   /**
    * Returns the bitset of special variable flags.  Internal use only.  This should just return 0 in custom
-   * implentations.
+   * implementations.
    *
    * @return Bitset of special flags.
    */

--- a/src/main/java/org/mvel2/templates/ExecutableValuePostProcessor.java
+++ b/src/main/java/org/mvel2/templates/ExecutableValuePostProcessor.java
@@ -1,0 +1,12 @@
+package org.mvel2.templates;
+
+public interface ExecutableValuePostProcessor {
+    String process(Object value);
+
+    ExecutableValuePostProcessor DEFAULT = new ExecutableValuePostProcessor() {
+        @Override
+        public String process(Object value) {
+            return String.valueOf(value);
+        }
+    };
+}

--- a/src/main/java/org/mvel2/templates/TemplateCompiler.java
+++ b/src/main/java/org/mvel2/templates/TemplateCompiler.java
@@ -332,7 +332,7 @@ public class TemplateCompiler {
   }
 
   private Node markTextNode(Node n) {
-    int s = (n.getEnd() > lastTextRangeEnding ? n.getEnd() : lastTextRangeEnding);
+    int s = Math.max(n.getEnd(), lastTextRangeEnding);
 
     if (s < start) {
       return n.next = new TextNode(s, lastTextRangeEnding = start - 1);

--- a/src/main/java/org/mvel2/templates/TemplateRuntime.java
+++ b/src/main/java/org/mvel2/templates/TemplateRuntime.java
@@ -46,6 +46,7 @@ public class TemplateRuntime {
   private Node rootNode;
   private String baseDir;
   private ExecutionStack relPath;
+  private ExecutableValuePostProcessor postProcessor = ExecutableValuePostProcessor.DEFAULT;
 
 
   public TemplateRuntime(char[] template, TemplateRegistry namedTemplateRegistry, Node rootNode, String baseDir) {
@@ -55,31 +56,31 @@ public class TemplateRuntime {
     this.baseDir = baseDir;
   }
 
-  public static Object eval(File file, Object ctx, VariableResolverFactory vars, TemplateRegistry registry) {
+  public static String eval(File file, Object ctx, VariableResolverFactory vars, TemplateRegistry registry) {
     return execute(compileTemplate(TemplateTools.readInFile(file)), ctx, vars, registry);
   }
 
-  public static Object eval(InputStream instream) {
+  public static String eval(InputStream instream) {
     return eval(instream, null, new ImmutableDefaultFactory(), null);
   }
 
-  public static Object eval(InputStream instream, Object ctx) {
+  public static String eval(InputStream instream, Object ctx) {
     return eval(instream, ctx, new ImmutableDefaultFactory(), null);
   }
 
-  public static Object eval(InputStream instream, Object ctx, VariableResolverFactory vars) {
+  public static String eval(InputStream instream, Object ctx, VariableResolverFactory vars) {
     return eval(instream, ctx, vars);
   }
 
-  public static Object eval(InputStream instream, Object ctx, Map vars) {
+  public static String eval(InputStream instream, Object ctx, Map vars) {
     return eval(instream, ctx, new MapVariableResolverFactory(vars), null);
   }
 
-  public static Object eval(InputStream instream, Object ctx, Map vars, TemplateRegistry registry) {
+  public static String eval(InputStream instream, Object ctx, Map vars, TemplateRegistry registry) {
     return execute(compileTemplate(TemplateTools.readStream(instream)), ctx, new MapVariableResolverFactory(vars), registry);
   }
 
-  public static Object eval(InputStream instream, Object ctx, VariableResolverFactory vars, TemplateRegistry registry) {
+  public static String eval(InputStream instream, Object ctx, VariableResolverFactory vars, TemplateRegistry registry) {
     return execute(compileTemplate(TemplateTools.readStream(instream)), ctx, vars, registry);
   }
 
@@ -87,7 +88,7 @@ public class TemplateRuntime {
     execute(compileTemplate(TemplateTools.readStream(instream)), ctx, vars, register, stream);
   }
 
-  public static Object eval(String template, Map vars) {
+  public static String eval(String template, Map vars) {
     return execute(compileTemplate(template), null, new MapVariableResolverFactory(vars));
   }
 
@@ -95,11 +96,11 @@ public class TemplateRuntime {
     execute(compileTemplate(template), null, new MapVariableResolverFactory(vars), null, stream);
   }
 
-  public static Object eval(String template, Object ctx) {
+  public static String eval(String template, Object ctx) {
     return execute(compileTemplate(template), ctx);
   }
 
-  public static Object eval(String template, Object ctx, Map vars) {
+  public static String eval(String template, Object ctx, Map vars) {
     return execute(compileTemplate(template), ctx, new MapVariableResolverFactory(vars));
   }
 
@@ -107,7 +108,7 @@ public class TemplateRuntime {
     execute(compileTemplate(template), ctx, new MapVariableResolverFactory(vars), null, stream);
   }
 
-  public static Object eval(String template, Object ctx, VariableResolverFactory vars) {
+  public static String eval(String template, Object ctx, VariableResolverFactory vars) {
     return execute(compileTemplate(template), ctx, vars);
   }
 
@@ -119,7 +120,7 @@ public class TemplateRuntime {
     execute(compileTemplate(template), ctx, vars, null, stream);
   }
 
-  public static Object eval(String template, Map vars, TemplateRegistry registry) {
+  public static String eval(String template, Map vars, TemplateRegistry registry) {
     return execute(compileTemplate(template), null, new MapVariableResolverFactory(vars), registry);
   }
 
@@ -131,7 +132,7 @@ public class TemplateRuntime {
     execute(compileTemplate(template), null, new MapVariableResolverFactory(vars), registry, stream);
   }
 
-  public static Object eval(String template, Object ctx, Map vars, TemplateRegistry registry) {
+  public static String eval(String template, Object ctx, Map vars, TemplateRegistry registry) {
     return execute(compileTemplate(template), ctx, new MapVariableResolverFactory(vars), registry);
   }
 
@@ -139,7 +140,7 @@ public class TemplateRuntime {
     execute(compileTemplate(template), ctx, new MapVariableResolverFactory(vars), registry, stream);
   }
 
-  public static Object eval(String template, Object ctx, VariableResolverFactory vars, TemplateRegistry registry) {
+  public static String eval(String template, Object ctx, VariableResolverFactory vars, TemplateRegistry registry) {
     return execute(compileTemplate(template), ctx, vars, registry);
   }
 
@@ -151,7 +152,7 @@ public class TemplateRuntime {
     execute(compileTemplate(template), ctx, vars, registry, stream);
   }
 
-  public static Object execute(CompiledTemplate compiled) {
+  public static String execute(CompiledTemplate compiled) {
     return execute(compiled.getRoot(), compiled.getTemplate(), new StringAppender(), null, new ImmutableDefaultFactory(), null);
   }
 
@@ -159,7 +160,7 @@ public class TemplateRuntime {
     execute(compiled.getRoot(), compiled.getTemplate(), new StandardOutputStream(stream), null, new ImmutableDefaultFactory(), null);
   }
 
-  public static Object execute(CompiledTemplate compiled, Object context) {
+  public static String execute(CompiledTemplate compiled, Object context) {
     return execute(compiled.getRoot(), compiled.getTemplate(), new StringAppender(), context, new ImmutableDefaultFactory(), null);
   }
 
@@ -167,7 +168,7 @@ public class TemplateRuntime {
     execute(compiled.getRoot(), compiled.getTemplate(), new StandardOutputStream(stream), context, new ImmutableDefaultFactory(), null);
   }
 
-  public static Object execute(CompiledTemplate compiled, Map vars) {
+  public static String execute(CompiledTemplate compiled, Map vars) {
     return execute(compiled.getRoot(), compiled.getTemplate(), new StringBuilder(), null, new MapVariableResolverFactory(vars), null);
   }
 
@@ -175,7 +176,7 @@ public class TemplateRuntime {
     execute(compiled.getRoot(), compiled.getTemplate(), new StandardOutputStream(stream), null, new MapVariableResolverFactory(vars), null);
   }
 
-  public static Object execute(CompiledTemplate compiled, Object context, Map vars) {
+  public static String execute(CompiledTemplate compiled, Object context, Map vars) {
     return execute(compiled.getRoot(), compiled.getTemplate(), new StringBuilder(), context, new MapVariableResolverFactory(vars), null);
   }
 
@@ -183,7 +184,7 @@ public class TemplateRuntime {
     execute(compiled.getRoot(), compiled.getTemplate(), new StandardOutputStream(stream), context, new MapVariableResolverFactory(vars), null);
   }
 
-  public static Object execute(CompiledTemplate compiled, Object context, TemplateRegistry registry) {
+  public static String execute(CompiledTemplate compiled, Object context, TemplateRegistry registry) {
     return execute(compiled.getRoot(), compiled.getTemplate(), new StringBuilder(), context, null, registry);
   }
 
@@ -191,7 +192,7 @@ public class TemplateRuntime {
     execute(compiled.getRoot(), compiled.getTemplate(), new StandardOutputStream(stream), context, null, registry);
   }
 
-  public static Object execute(CompiledTemplate compiled, Object context, Map vars, TemplateRegistry registry) {
+  public static String execute(CompiledTemplate compiled, Object context, Map vars, TemplateRegistry registry) {
     return execute(compiled.getRoot(), compiled.getTemplate(), new StringBuilder(), context, new MapVariableResolverFactory(vars), registry);
   }
 
@@ -199,19 +200,19 @@ public class TemplateRuntime {
     execute(compiled.getRoot(), compiled.getTemplate(), new StandardOutputStream(stream), context, new MapVariableResolverFactory(vars), registry);
   }
 
-  public static Object execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory) {
+  public static String execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory) {
     return execute(compiled.getRoot(), compiled.getTemplate(), new StringBuilder(), context, factory, null);
   }
 
-  public static Object execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, TemplateRegistry registry) {
+  public static String execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, TemplateRegistry registry) {
     return execute(compiled.getRoot(), compiled.getTemplate(), new StringBuilder(), context, factory, registry);
   }
 
-  public static Object execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, String baseDir) {
+  public static String execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, String baseDir) {
     return execute(compiled.getRoot(), compiled.getTemplate(), new StringBuilder(), context, factory, null, baseDir);
   }
 
-  public static Object execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, TemplateRegistry registry, String baseDir) {
+  public static String execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, TemplateRegistry registry, String baseDir) {
     return execute(compiled.getRoot(), compiled.getTemplate(), new StringBuilder(), context, factory, registry, baseDir);
   }
 
@@ -223,53 +224,53 @@ public class TemplateRuntime {
     execute(compiled.getRoot(), compiled.getTemplate(), new StandardOutputStream(stream), context, factory, null, baseDir);
   }
 
-  public static Object execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, TemplateRegistry registry, OutputStream stream) {
+  public static String execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, TemplateRegistry registry, OutputStream stream) {
     return execute(compiled.getRoot(), compiled.getTemplate(), new StandardOutputStream(stream), context, factory, registry);
   }
 
 
-  public static Object execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, TemplateRegistry registry, TemplateOutputStream stream) {
+  public static String execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, TemplateRegistry registry, TemplateOutputStream stream) {
     return execute(compiled.getRoot(), compiled.getTemplate(), stream, context, factory, registry);
   }
 
-  public static Object execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, TemplateRegistry registry, TemplateOutputStream stream, String basedir) {
+  public static String execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, TemplateRegistry registry, TemplateOutputStream stream, String basedir) {
     return execute(compiled.getRoot(), compiled.getTemplate(), stream, context, factory, registry, basedir);
   }
 
-  public static Object execute(Node root, char[] template,
+  public static String execute(Node root, char[] template,
                                StringAppender appender, Object context,
                                VariableResolverFactory factory, TemplateRegistry registry) {
 
     return new TemplateRuntime(template, registry, root, ".").execute(appender, context, factory);
   }
 
-  public Object execute(StringBuilder appender, Object context, VariableResolverFactory factory) {
+  public String execute(StringBuilder appender, Object context, VariableResolverFactory factory) {
     return execute(new StringBuilderStream(appender), context, factory);
   }
 
 
-  public static Object execute(Node root, char[] template,
+  public static String execute(Node root, char[] template,
                                StringBuilder appender, Object context,
                                VariableResolverFactory factory, TemplateRegistry registry) {
 
     return new TemplateRuntime(template, registry, root, ".").execute(appender, context, factory);
   }
 
-  public static Object execute(Node root, char[] template,
+  public static String execute(Node root, char[] template,
                                StringBuilder appender, Object context,
                                VariableResolverFactory factory, TemplateRegistry registry, String baseDir) {
 
     return new TemplateRuntime(template, registry, root, baseDir).execute(appender, context, factory);
   }
 
-  public static Object execute(Node root, char[] template,
+  public static String execute(Node root, char[] template,
                                TemplateOutputStream appender, Object context,
                                VariableResolverFactory factory, TemplateRegistry registry) {
 
     return new TemplateRuntime(template, registry, root, ".").execute(appender, context, factory);
   }
 
-  public static Object execute(Node root, char[] template,
+  public static String execute(Node root, char[] template,
                                TemplateOutputStream appender, Object context,
                                VariableResolverFactory factory, TemplateRegistry registry, String baseDir) {
 
@@ -277,12 +278,21 @@ public class TemplateRuntime {
   }
 
 
-  public Object execute(StringAppender appender, Object context, VariableResolverFactory factory) {
+  public String execute(StringAppender appender, Object context, VariableResolverFactory factory) {
     return execute(new StringAppenderStream(appender), context, factory);
   }
 
-  public Object execute(TemplateOutputStream stream, Object context, VariableResolverFactory factory) {
-    return rootNode.eval(this, stream, context, factory);
+  public String execute(TemplateOutputStream stream, Object context, VariableResolverFactory factory) {
+    execute(rootNode, stream, context, factory);
+    return stream.toString();
+  }
+
+  public void execute(Node startNode, TemplateOutputStream stream, Object context, VariableResolverFactory factory) {
+    Node node = startNode;
+    while (node != null) {
+      node.eval(this, stream, context, factory);
+      node = node.getNextExecutableNode(context, factory);
+    }
   }
 
   public Node getRootNode() {
@@ -315,5 +325,9 @@ public class TemplateRuntime {
       relPath.push(baseDir);
     }
     return relPath;
+  }
+
+  public ExecutableValuePostProcessor getPostProcessor() {
+    return postProcessor;
   }
 }

--- a/src/main/java/org/mvel2/templates/res/CodeNode.java
+++ b/src/main/java/org/mvel2/templates/res/CodeNode.java
@@ -49,9 +49,8 @@ public class CodeNode extends Node {
     this.offset = end - start - 1;
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
     MVEL.eval(contents, start, offset, ctx, factory);
-    return next != null ? next.eval(runtime, appender, ctx, factory) : null;
   }
 
   public boolean demarcate(Node terminatingNode, char[] template) {

--- a/src/main/java/org/mvel2/templates/res/CommentNode.java
+++ b/src/main/java/org/mvel2/templates/res/CommentNode.java
@@ -37,11 +37,8 @@ public class CommentNode extends Node {
     this.next = next;
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
-    if (next != null)
-      return next.eval(runtime, appender, ctx, factory);
-    else
-      return null;
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+    // do nothing
   }
 
   public boolean demarcate(Node terminatingNode, char[] template) {

--- a/src/main/java/org/mvel2/templates/res/CompiledCodeNode.java
+++ b/src/main/java/org/mvel2/templates/res/CompiledCodeNode.java
@@ -46,9 +46,8 @@ public class CompiledCodeNode extends Node {
 //                   context);
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
     MVEL.executeExpression(ce, ctx, factory);
-    return next != null ? next.eval(runtime, appender, ctx, factory) : null;
   }
 
   public boolean demarcate(Node terminatingNode, char[] template) {

--- a/src/main/java/org/mvel2/templates/res/CompiledDeclareNode.java
+++ b/src/main/java/org/mvel2/templates/res/CompiledDeclareNode.java
@@ -43,7 +43,7 @@ public class CompiledDeclareNode extends Node {
     //  ce = MVEL.compileExpression(this.contents = subset(template, this.cStart = start, (this.end = this.cEnd = end) - start - 1), context);
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
     if (runtime.getNamedTemplateRegistry() == null) {
       runtime.setNamedTemplateRegistry(new SimpleTemplateRegistry());
     }
@@ -51,8 +51,6 @@ public class CompiledDeclareNode extends Node {
     runtime.getNamedTemplateRegistry()
         .addNamedTemplate(MVEL.executeExpression(ce, ctx, factory, String.class),
             new CompiledTemplate(runtime.getTemplate(), nestedNode));
-
-    return next != null ? next.eval(runtime, appender, ctx, factory) : null;
   }
 
   public boolean demarcate(Node terminatingNode, char[] template) {

--- a/src/main/java/org/mvel2/templates/res/CompiledEvalNode.java
+++ b/src/main/java/org/mvel2/templates/res/CompiledEvalNode.java
@@ -41,9 +41,8 @@ public class CompiledEvalNode extends Node {
     ce = MVEL.compileExpression(template, cStart, cEnd - cStart, context);
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
-    appender.append(String.valueOf(TemplateRuntime.eval(valueOf(MVEL.executeExpression(ce, ctx, factory)), ctx, factory)));
-    return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+    appender.append(runtime.getPostProcessor().process(TemplateRuntime.eval(valueOf(MVEL.executeExpression(ce, ctx, factory)), ctx, factory)));
   }
 
   public boolean demarcate(Node terminatingNode, char[] template) {

--- a/src/main/java/org/mvel2/templates/res/CompiledExpressionNode.java
+++ b/src/main/java/org/mvel2/templates/res/CompiledExpressionNode.java
@@ -26,8 +26,6 @@ import org.mvel2.templates.util.TemplateOutputStream;
 
 import java.io.Serializable;
 
-import static java.lang.String.valueOf;
-
 public class CompiledExpressionNode extends ExpressionNode {
   private Serializable ce;
 
@@ -41,9 +39,8 @@ public class CompiledExpressionNode extends ExpressionNode {
     ce = MVEL.compileExpression(template, cStart, cEnd - cStart, context);
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
-    appender.append(valueOf(MVEL.executeExpression(ce, ctx, factory)));
-    return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+    appender.append(runtime.getPostProcessor().process(MVEL.executeExpression(ce, ctx, factory)));
   }
 
   public String toString() {

--- a/src/main/java/org/mvel2/templates/res/CompiledForEachNode.java
+++ b/src/main/java/org/mvel2/templates/res/CompiledForEachNode.java
@@ -76,7 +76,7 @@ public class CompiledForEachNode extends Node {
     return false;
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
     Iterator[] iters = new Iterator[item.length];
 
     Object o;
@@ -111,12 +111,12 @@ public class CompiledForEachNode extends Node {
         }
       }
       if (iterate != 0) {
-        nestedNode.eval(runtime, appender, ctx, localFactory);
+        runtime.execute(nestedNode, appender, context, localFactory);
 
         if (sepExpr != null) {
           for (Iterator it : iters) {
             if (it.hasNext()) {
-              appender.append(String.valueOf(MVEL.executeExpression(cSepExpr, ctx, factory)));
+              appender.append(runtime.getPostProcessor().process(MVEL.executeExpression(cSepExpr, ctx, factory)));
               break;
             }
           }
@@ -124,8 +124,6 @@ public class CompiledForEachNode extends Node {
       }
       else break;
     }
-
-    return next != null ? next.eval(runtime, appender, ctx, factory) : null;
   }
 
   private void configure() {

--- a/src/main/java/org/mvel2/templates/res/CompiledIfNode.java
+++ b/src/main/java/org/mvel2/templates/res/CompiledIfNode.java
@@ -39,10 +39,15 @@ public class CompiledIfNode extends IfNode {
     }
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+  @Override
+  public Node getNextExecutableNode(Object ctx, VariableResolverFactory factory) {
     if (ce == null || MVEL.executeExpression(ce, ctx, factory, Boolean.class)) {
-      return trueNode.eval(runtime, appender, ctx, factory);
+      return trueNode;
     }
-    return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+    return next;
+  }
+
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+    // do nothing
   }
 }

--- a/src/main/java/org/mvel2/templates/res/CompiledIncludeNode.java
+++ b/src/main/java/org/mvel2/templates/res/CompiledIncludeNode.java
@@ -56,19 +56,16 @@ public class CompiledIncludeNode extends Node {
     }
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
     String file = MVEL.executeExpression(cIncludeExpression, ctx, factory, String.class);
 
     if (this.cPreExpression != null) {
       MVEL.executeExpression(cPreExpression, ctx, factory);
     }
-
-    if (next != null) {
-      return next.eval(runtime, appender.append(String.valueOf(TemplateRuntime.eval(readFile(runtime, file, ctx, factory), ctx, factory))), ctx, factory);
-    }
-    else {
-      return appender.append(String.valueOf(MVEL.eval(readFile(runtime, file, ctx, factory), ctx, factory)));
-    }
+    final Object value = next != null ?
+            TemplateRuntime.eval(readFile(runtime, file, ctx, factory), ctx, factory) :
+            MVEL.eval(readFile(runtime, file, ctx, factory));
+    appender.append(runtime.getPostProcessor().process(value));
   }
 
   private String readFile(TemplateRuntime runtime, String fileName, Object ctx, VariableResolverFactory factory) {

--- a/src/main/java/org/mvel2/templates/res/CompiledTerminalExpressionNode.java
+++ b/src/main/java/org/mvel2/templates/res/CompiledTerminalExpressionNode.java
@@ -35,8 +35,8 @@ public class CompiledTerminalExpressionNode extends TerminalExpressionNode {
     ce = MVEL.compileExpression(node.contents, node.cStart, node.cEnd - node.cStart, context);
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
-    return MVEL.executeExpression(ce, ctx, factory);
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+      appender.append(runtime.getPostProcessor().process(MVEL.executeExpression(ce, ctx, factory)));
   }
 
   public boolean demarcate(Node terminatingNode, char[] template) {

--- a/src/main/java/org/mvel2/templates/res/DeclareNode.java
+++ b/src/main/java/org/mvel2/templates/res/DeclareNode.java
@@ -38,7 +38,7 @@ public class DeclareNode extends Node {
     //    this.contents = subset(template, this.cStart = start, (this.end = this.cEnd = end) - start - 1);
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
     if (runtime.getNamedTemplateRegistry() == null) {
       runtime.setNamedTemplateRegistry(new SimpleTemplateRegistry());
     }
@@ -46,8 +46,6 @@ public class DeclareNode extends Node {
     runtime.getNamedTemplateRegistry()
         .addNamedTemplate(MVEL.eval(contents, cStart, cEnd - cStart, ctx, factory, String.class),
             new CompiledTemplate(runtime.getTemplate(), nestedNode));
-
-    return next != null ? next.eval(runtime, appender, ctx, factory) : null;
   }
 
   public boolean demarcate(Node terminatingNode, char[] template) {

--- a/src/main/java/org/mvel2/templates/res/EndNode.java
+++ b/src/main/java/org/mvel2/templates/res/EndNode.java
@@ -23,8 +23,8 @@ import org.mvel2.templates.TemplateRuntime;
 import org.mvel2.templates.util.TemplateOutputStream;
 
 public class EndNode extends Node {
-  public Object eval(TemplateRuntime runtie, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
-    return appender.toString();
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+     // do nothing
   }
 
   public String toString() {

--- a/src/main/java/org/mvel2/templates/res/EvalNode.java
+++ b/src/main/java/org/mvel2/templates/res/EvalNode.java
@@ -50,10 +50,9 @@ public class EvalNode extends Node {
     this.next = next;
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
-    appender.append(String.valueOf(TemplateRuntime.eval(
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+    appender.append(runtime.getPostProcessor().process(TemplateRuntime.eval(
         valueOf(MVEL.eval(contents, cStart, cEnd - cStart, ctx, factory)), ctx, factory)));
-    return next != null ? next.eval(runtime, appender, ctx, factory) : null;
   }
 
   public boolean demarcate(Node terminatingNode, char[] template) {

--- a/src/main/java/org/mvel2/templates/res/ExpressionNode.java
+++ b/src/main/java/org/mvel2/templates/res/ExpressionNode.java
@@ -23,8 +23,6 @@ import org.mvel2.integration.VariableResolverFactory;
 import org.mvel2.templates.TemplateRuntime;
 import org.mvel2.templates.util.TemplateOutputStream;
 
-import static java.lang.String.valueOf;
-
 public class ExpressionNode extends Node {
   public ExpressionNode() {
   }
@@ -50,9 +48,8 @@ public class ExpressionNode extends Node {
     this.next = next;
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
-    appender.append(valueOf(MVEL.eval(contents, cStart, cEnd - cStart, ctx, factory)));
-    return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+    appender.append(runtime.getPostProcessor().process(MVEL.eval(contents, cStart, cEnd - cStart, ctx, factory)));
   }
 
   public boolean demarcate(Node terminatingNode, char[] template) {

--- a/src/main/java/org/mvel2/templates/res/ForEachNode.java
+++ b/src/main/java/org/mvel2/templates/res/ForEachNode.java
@@ -64,7 +64,7 @@ public class ForEachNode extends Node {
     return false;
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
     Iterator[] iters = new Iterator[item.length];
 
     Object o;
@@ -101,7 +101,7 @@ public class ForEachNode extends Node {
         if (sepExpr != null) {
           for (Iterator it : iters) {
             if (it.hasNext()) {
-              appender.append(String.valueOf(MVEL.eval(sepExpr, ctx, factory)));
+              appender.append(runtime.getPostProcessor().process(MVEL.eval(sepExpr, ctx, factory)));
               break;
             }
           }
@@ -109,8 +109,6 @@ public class ForEachNode extends Node {
       }
       else break;
     }
-
-    return next != null ? next.eval(runtime, appender, ctx, factory) : null;
   }
 
   private void configure() {

--- a/src/main/java/org/mvel2/templates/res/IfNode.java
+++ b/src/main/java/org/mvel2/templates/res/IfNode.java
@@ -55,10 +55,15 @@ public class IfNode extends Node {
     return true;
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+  @Override
+  public Node getNextExecutableNode(Object ctx, VariableResolverFactory factory) {
     if (cEnd == cStart || MVEL.eval(contents, cStart, cEnd - cStart, ctx, factory, Boolean.class)) {
-      return trueNode.eval(runtime, appender, ctx, factory);
+      return trueNode;
     }
-    return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+    return next;
+  }
+
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+    // do nothing
   }
 }

--- a/src/main/java/org/mvel2/templates/res/IncludeNode.java
+++ b/src/main/java/org/mvel2/templates/res/IncludeNode.java
@@ -57,19 +57,16 @@ public class IncludeNode extends Node {
 //        if (mark != contents.length) this.preExpression = subset(contents, ++mark, contents.length - mark);
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
     String file = MVEL.eval(contents, includeStart, includeOffset, ctx, factory, String.class);
 
     if (preOffset != 0) {
       MVEL.eval(contents, preStart, preOffset, ctx, factory);
     }
-
-    if (next != null) {
-      return next.eval(runtime, appender.append(String.valueOf(TemplateRuntime.eval(readInFile(runtime, file), ctx, factory))), ctx, factory);
-    }
-    else {
-      return appender.append(String.valueOf(MVEL.eval(readInFile(runtime, file), ctx, factory)));
-    }
+    final Object value = next != null ?
+            TemplateRuntime.eval(readInFile(runtime, file), ctx, factory) :
+            MVEL.eval(readInFile(runtime, file), ctx, factory);
+    appender.append(runtime.getPostProcessor().process(value));
   }
 
   public boolean demarcate(Node terminatingNode, char[] template) {

--- a/src/main/java/org/mvel2/templates/res/NamedIncludeNode.java
+++ b/src/main/java/org/mvel2/templates/res/NamedIncludeNode.java
@@ -55,22 +55,13 @@ public class NamedIncludeNode extends Node {
 //        if (mark != contents.length) this.preExpression = subset(contents, ++mark, contents.length - mark);
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
     if (preOffset != 0) {
       MVEL.eval(contents, preStart, preOffset, ctx, factory);
     }
-
-    if (next != null) {
-      return next.eval(runtime,
-          appender.append(String.valueOf(TemplateRuntime.execute(runtime
-              .getNamedTemplateRegistry().getNamedTemplate(MVEL.eval(contents, includeStart, includeOffset,
-                  ctx, factory, String.class)), ctx, factory))), ctx, factory);
-    }
-    else {
-      return appender.append(String.valueOf(TemplateRuntime.execute(runtime.getNamedTemplateRegistry()
-          .getNamedTemplate(MVEL.eval(contents, includeStart, includeOffset, ctx, factory, String.class)),
-          ctx, factory)));
-    }
+    appender.append(runtime.getPostProcessor().process(TemplateRuntime.execute(runtime.getNamedTemplateRegistry()
+                    .getNamedTemplate(MVEL.eval(contents, includeStart, includeOffset, ctx, factory, String.class)),
+            ctx, factory)));
   }
 
   public boolean demarcate(Node terminatingNode, char[] template) {

--- a/src/main/java/org/mvel2/templates/res/Node.java
+++ b/src/main/java/org/mvel2/templates/res/Node.java
@@ -60,7 +60,7 @@ public abstract class Node implements Serializable {
     this.next = next;
   }
 
-  public abstract Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory);
+  public abstract void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory);
 
   public String getName() {
     return name;
@@ -138,5 +138,9 @@ public abstract class Node implements Serializable {
 
   public int getLength() {
     return this.end - this.begin;
+  }
+
+  public Node getNextExecutableNode(Object ctx, VariableResolverFactory factory) {
+    return this.next;
   }
 }

--- a/src/main/java/org/mvel2/templates/res/TerminalExpressionNode.java
+++ b/src/main/java/org/mvel2/templates/res/TerminalExpressionNode.java
@@ -35,8 +35,8 @@ public class TerminalExpressionNode extends Node {
     this.cEnd = node.cEnd;
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
-    return MVEL.eval(contents, cStart, cEnd - cStart, ctx, factory);
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+     appender.append(runtime.getPostProcessor().process(MVEL.eval(contents, cStart, cEnd - cStart, ctx, factory)));
   }
 
   public boolean demarcate(Node terminatingNode, char[] template) {

--- a/src/main/java/org/mvel2/templates/res/TerminalNode.java
+++ b/src/main/java/org/mvel2/templates/res/TerminalNode.java
@@ -31,8 +31,8 @@ public class TerminalNode extends Node {
     this.end = end;
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
-    return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+    // do nothing
   }
 
   public boolean demarcate(Node terminatingNode, char[] template) {

--- a/src/main/java/org/mvel2/templates/res/TextNode.java
+++ b/src/main/java/org/mvel2/templates/res/TextNode.java
@@ -34,12 +34,11 @@ public class TextNode extends Node {
     this.next = next;
   }
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
     int len = end - begin;
     if (len != 0) {
       appender.append(new String(runtime.getTemplate(), begin, len));
     }
-    return next != null ? next.eval(runtime, appender, ctx, factory) : null;
   }
 
   public String toString() {

--- a/src/main/java/org/mvel2/util/ExecutionStack.java
+++ b/src/main/java/org/mvel2/util/ExecutionStack.java
@@ -20,7 +20,6 @@ package org.mvel2.util;
 
 import org.mvel2.ScriptRuntimeException;
 
-import static java.lang.String.valueOf;
 import static org.mvel2.math.MathProcessor.doOperations;
 
 public class ExecutionStack {
@@ -220,7 +219,7 @@ public class ExecutionStack {
 
     StringBuilder appender = new StringBuilder().append("[");
     do {
-      appender.append(valueOf(el.value));
+      appender.append(el.value);
       if (el.next != null) appender.append(", ");
     }
     while ((el = el.next) != null);

--- a/src/test/java/org/mvel2/tests/templates/TemplateTests.java
+++ b/src/test/java/org/mvel2/tests/templates/TemplateTests.java
@@ -23,7 +23,13 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.math.BigDecimal;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.mvel2.templates.TemplateCompiler.compileTemplate;
 
@@ -76,7 +82,7 @@ public class TemplateTests extends TestCase {
                 });
     }
 
-    public Object test(String template) {
+    public String test(String template) {
         CompiledTemplate compiled = compileTemplate(template);
         return TemplateRuntime.execute(compiled, base, vrf);
     }
@@ -204,7 +210,7 @@ public class TemplateTests extends TestCase {
     public void testExpressions() {
         String s = "@{_foo_.length()}";
         Object r = test(s);
-        assertEquals(3, r);
+        assertEquals("3", r);
     }
 
     public void testCode() {
@@ -254,19 +260,19 @@ public class TemplateTests extends TestCase {
     }
 
     public void testBooleanOperator() {
-        assertEquals(true, test("@{foo.bar.woof == true}"));
+        assertEquals("true", test("@{foo.bar.woof == true}"));
     }
 
     public void testBooleanOperator2() {
-        assertEquals(false, test("@{foo.bar.woof == false}"));
+        assertEquals("false", test("@{foo.bar.woof == false}"));
     }
 
     public void testTextComparison() {
-        assertEquals(true, test("@{foo.bar.name == 'dog'}"));
+        assertEquals("true", test("@{foo.bar.name == 'dog'}"));
     }
 
     public void testNETextComparison() {
-        assertEquals(true, test("@{foo.bar.name != 'foo'}"));
+        assertEquals("true", test("@{foo.bar.name != 'foo'}"));
     }
 
     public void testChor() {
@@ -278,15 +284,15 @@ public class TemplateTests extends TestCase {
     }
 
     public void testNullCompare() {
-        assertEquals(true, test("@{c != null}"));
+        assertEquals("true", test("@{c != null}"));
     }
 
     public void testAnd() {
-        assertEquals(true, test("@{c != null && foo.bar.name == 'dog' && foo.bar.woof}"));
+        assertEquals("true", test("@{c != null && foo.bar.name == 'dog' && foo.bar.woof}"));
     }
 
     public void testMath() {
-        assertEquals(188.4, test("@{pi * hour}"));
+        assertEquals("188.4", test("@{pi * hour}"));
     }
 
     public void testTemplating() {
@@ -294,19 +300,19 @@ public class TemplateTests extends TestCase {
     }
 
     public void testComplexAnd() {
-        assertEquals(true, test("@{(pi * hour) > 0 && foo.happy() == 'happyBar'}"));
+        assertEquals("true", test("@{(pi * hour) > 0 && foo.happy() == 'happyBar'}"));
     }
 
     public void testModulus() {
-        assertEquals(38392 % 2,
+        assertEquals("" + (38392 % 2),
                 test("@{38392 % 2}"));
     }
 
     public void testLessThan() {
-        assertEquals(true, test("@{pi < 3.15}"));
-        assertEquals(true, test("@{pi <= 3.14}"));
-        assertEquals(false, test("@{pi > 3.14}"));
-        assertEquals(true, test("@{pi >= 3.14}"));
+        assertEquals("true", test("@{pi < 3.15}"));
+        assertEquals("true", test("@{pi <= 3.14}"));
+        assertEquals("false", test("@{pi > 3.14}"));
+        assertEquals("true", test("@{pi >= 3.14}"));
     }
 
     public void testMethodAccess() {
@@ -318,11 +324,11 @@ public class TemplateTests extends TestCase {
     }
 
     public void testMethodAccess3() {
-        assertEquals(true, test("@{equalityCheck(c, 'cat')}"));
+        assertEquals("true", test("@{equalityCheck(c, 'cat')}"));
     }
 
     public void testMethodAccess4() {
-        assertEquals(null, test("@{readBack(null)}"));
+        assertEquals("null", test("@{readBack(null)}"));
     }
 
     public void testMethodAccess5() {
@@ -330,27 +336,27 @@ public class TemplateTests extends TestCase {
     }
 
     public void testMethodAccess6() {
-        assertEquals(false, test("@{!foo.bar.isWoof()}"));
+        assertEquals("false", test("@{!foo.bar.isWoof()}"));
     }
 
     public void testNegation() {
-        assertEquals(true, test("@{!fun && !fun}"));
+        assertEquals("true", test("@{!fun && !fun}"));
     }
 
     public void testNegation2() {
-        assertEquals(false, test("@{fun && !fun}"));
+        assertEquals("false", test("@{fun && !fun}"));
     }
 
     public void testNegation3() {
-        assertEquals(true, test("@{!(fun && fun)}"));
+        assertEquals("true", test("@{!(fun && fun)}"));
     }
 
     public void testNegation4() {
-        assertEquals(false, test("@{(fun && fun)}"));
+        assertEquals("false", test("@{(fun && fun)}"));
     }
 
     public void testMultiStatement() {
-        assertEquals(true, test("@{populate(); barfoo == 'sarah'}"));
+        assertEquals("true", test("@{populate(); barfoo == 'sarah'}"));
     }
 
     public void testAssignment2() {
@@ -358,19 +364,19 @@ public class TemplateTests extends TestCase {
     }
 
     public void testOr() {
-        assertEquals(true, test("@{fun || true}"));
+        assertEquals("true", test("@{fun || true}"));
     }
 
     public void testLiteralPassThrough() {
-        assertEquals(true, test("@{true}"));
+        assertEquals("true", test("@{true}"));
     }
 
     public void testLiteralPassThrough2() {
-        assertEquals(false, test("@{false}"));
+        assertEquals("false", test("@{false}"));
     }
 
     public void testLiteralPassThrough3() {
-        assertEquals(null, test("@{null}"));
+        assertEquals("null", test("@{null}"));
     }
 
     public void testControlLoopList() {
@@ -445,23 +451,23 @@ public class TemplateTests extends TestCase {
     }
 
     public void testRegEx() {
-        assertEquals(true, test("@{foo.bar.name ~= '[a-z].+'}"));
+        assertEquals("true", test("@{foo.bar.name ~= '[a-z].+'}"));
     }
 
     public void testRegExNegate() {
-        assertEquals(false, test("@{!(foo.bar.name ~= '[a-z].+')}"));
+        assertEquals("false", test("@{!(foo.bar.name ~= '[a-z].+')}"));
     }
 
     public void testRegEx2() {
-        assertEquals(true, test("@{foo.bar.name ~= '[a-z].+' && foo.bar.name != null}"));
+        assertEquals("true", test("@{foo.bar.name ~= '[a-z].+' && foo.bar.name != null}"));
     }
 
     public void testBlank() {
-        assertEquals(true, test("@{'' == empty}"));
+        assertEquals("true", test("@{'' == empty}"));
     }
 
     public void testBlank2() {
-        assertEquals(true, test("@{BWAH == empty}"));
+        assertEquals("true", test("@{BWAH == empty}"));
     }
 
     public void testTernary() {
@@ -489,71 +495,71 @@ public class TemplateTests extends TestCase {
     }
 
     public void testInstanceCheck1() {
-        assertEquals(true, test("@{c is java.lang.String}"));
+        assertEquals("true", test("@{c is java.lang.String}"));
     }
 
     public void testInstanceCheck2() {
-        assertEquals(false, test("@{pi is java.lang.Integer}"));
+        assertEquals("false", test("@{pi is java.lang.Integer}"));
     }
 
     public void testBitwiseOr1() {
-        assertEquals(6, test("@{2 | 4}"));
+        assertEquals("6", test("@{2 | 4}"));
     }
 
     public void testBitwiseOr2() {
-        assertEquals(true, test("@{(2 | 1) > 0}"));
+        assertEquals("true", test("@{(2 | 1) > 0}"));
     }
 
     public void testBitwiseOr3() {
-        assertEquals(true, test("@{(2 | 1) == 3}"));
+        assertEquals("true", test("@{(2 | 1) == 3}"));
     }
 
     public void testBitwiseAnd1() {
-        assertEquals(2, test("@{2 & 3}"));
+        assertEquals("2", test("@{2 & 3}"));
     }
 
     public void testShiftLeft() {
-        assertEquals(4, test("@{2 << 1}"));
+        assertEquals("4", test("@{2 << 1}"));
     }
 
     public void testUnsignedShiftLeft() {
-        assertEquals(2, test("@{-2 <<< 0}"));
+        assertEquals("2", test("@{-2 <<< 0}"));
     }
 
     public void testShiftRight() {
-        assertEquals(128, test("@{256 >> 1}"));
+        assertEquals("128", test("@{256 >> 1}"));
     }
 
     public void testXOR() {
-        assertEquals(3, test("@{1 ^ 2}"));
+        assertEquals("3", test("@{1 ^ 2}"));
     }
 
     public void testContains1() {
-        assertEquals(true, test("@{list contains 'Happy!'}"));
+        assertEquals("true", test("@{list contains 'Happy!'}"));
     }
 
     public void testContains2() {
-        assertEquals(false, test("@{list contains 'Foobie'}"));
+        assertEquals("false", test("@{list contains 'Foobie'}"));
     }
 
     public void testContains3() {
-        assertEquals(true, test("@{sentence contains 'fox'}"));
+        assertEquals("true", test("@{sentence contains 'fox'}"));
     }
 
     public void testContains4() {
-        assertEquals(false, test("@{sentence contains 'mike'}"));
+        assertEquals("false", test("@{sentence contains 'mike'}"));
     }
 
     public void testContains5() {
-        assertEquals(true, test("@{!(sentence contains 'mike')}"));
+        assertEquals("true", test("@{!(sentence contains 'mike')}"));
     }
 
     public void testTokenMethodAccess() {
-        assertEquals(String.class, test("@{a = 'foo'; a.getClass()}"));
+        assertEquals("String", test("@{a = 'foo'; a.getClass().getSimpleName()}"));
     }
 
     public void testArrayCreationWithLength() {
-        assertEquals(2, test("@{Array.getLength({'foo', 'bar'})}"));
+        assertEquals("2", test("@{Array.getLength({'foo', 'bar'})}"));
     }
 
     public void testMapCreation() {
@@ -561,11 +567,11 @@ public class TemplateTests extends TestCase {
     }
 
     public void testProjectionSupport() {
-        assertEquals(true, test("@{(name in things) contains 'Bob'}"));
+        assertEquals("true", test("@{(name in things) contains 'Bob'}"));
     }
 
     public void testProjectionSupport2() {
-        assertEquals(3, test("@{(name in things).size()}"));
+        assertEquals("3", test("@{(name in things).size()}"));
     }
 
     public void testObjectInstantiation() {
@@ -593,15 +599,11 @@ public class TemplateTests extends TestCase {
     }
 
     public void testSoundex() {
-        assertTrue((Boolean) test("@{'foobar' soundslike 'fubar'}"));
+        assertEquals("true", test("@{'foobar' soundslike 'fubar'}"));
     }
 
     public void testSoundex2() {
-        assertFalse((Boolean) test("@{'flexbar' soundslike 'fubar'}"));
-    }
-
-    public void testThisReference() {
-        assertEquals(true, test("@{this}") instanceof Base);
+        assertEquals("false", test("@{'flexbar' soundslike 'fubar'}"));
     }
 
     public void testIfLoopInTemplate() {
@@ -637,7 +639,7 @@ public class TemplateTests extends TestCase {
         String template = "@foreach{item : list}a@end{}";
         Map map = new HashMap();
         map.put("list", list);
-        String r = (String) TemplateRuntime.eval(template, map);
+        String r = TemplateRuntime.eval(template, map);
         System.out.println("r: " + r);
         assertEquals("aaa", r);
     }
@@ -646,7 +648,7 @@ public class TemplateTests extends TestCase {
         Folder f1 = new Folder("f1", null);
 
         String template = "@{name} @foreach{item : children}a@end{}";
-        String r = (String) TemplateRuntime.eval(template, f1);
+        String r = TemplateRuntime.eval(template, f1);
         System.out.println("r: " + r);
     }
 
@@ -657,7 +659,7 @@ public class TemplateTests extends TestCase {
         String template = "@foreach{item : list}a@end{}";
         Map map = new HashMap();
         map.put("list", list);
-        String r = (String) TemplateRuntime.eval(template, map);
+        String r = TemplateRuntime.eval(template, map);
         System.out.println("r: " + r);
         assertEquals("aaa", r);
     }
@@ -991,14 +993,24 @@ public class TemplateTests extends TestCase {
         Map<String, Object> context = new HashMap<String, Object>();
         context.put( "root", new Node( 2,
                                        Arrays.asList( new Node( 1,
-                                                                Collections.EMPTY_LIST ) ) ) );
+                                                                Collections.<Node>emptyList() ) ) ) );
 
 
-        String result = (String) TemplateRuntime.execute( reportRegistry.getNamedTemplate( "drl" ),
+        String result = TemplateRuntime.execute( reportRegistry.getNamedTemplate( "drl" ),
                                                           null,
                                                           new MapVariableResolverFactory( context ),
                                                           reportRegistry );
 
         assertEquals("OR AND AND OR", result);
+    }
+
+    public void testStackOverflow() {
+        StringBuilder templateBuilder = new StringBuilder();
+        for (int i = 1; i < 5000; i++) {
+            templateBuilder.append("Line ").append(i).append(" value: ${value}\n");
+        }
+        final String template = templateBuilder.toString();
+        final Object result = TemplateRuntime.eval(template, Collections.singletonMap("value", "Test Value"));
+        assertEquals(template.replace("${value}", "Test Value"), result);
     }
 }

--- a/src/test/java/org/mvel2/tests/templates/tests/res/TestPluginNode.java
+++ b/src/test/java/org/mvel2/tests/templates/tests/res/TestPluginNode.java
@@ -4,16 +4,11 @@ import org.mvel2.integration.VariableResolverFactory;
 import org.mvel2.templates.TemplateRuntime;
 import org.mvel2.templates.util.TemplateOutputStream;
 import org.mvel2.templates.res.Node;
-import org.mvel2.util.StringAppender;
-
-import java.io.PrintStream;
-import java.io.PrintWriter;
 
 public class TestPluginNode extends Node {
 
-  public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+  public void eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
     appender.append("THIS_IS_A_TEST");
-    return next != null ? next.eval(runtime, appender, ctx, factory) : null;
   }
 
   public boolean demarcate(Node terminatingNode, char[] template) {


### PR DESCRIPTION
Public Template API has changed, so release as a new version.
Changes:
* TemplateRuntime.eval always returns String. In past, it could return any Object if no string concatenation was applied
* Possible execution of templates with arbitary number of parameters. In past, StackOverflowError was raised on about 3000 subexpressions.
* Pre-processors and post-processors support for subexpressions which gives opportunity to modify the expression before it is compiled by MVEL, and format evaluation result, e.g. apply number rounding